### PR TITLE
Removing provisioner tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ```hcl
 module "virtual-service" {
-    source = "github.com/pbs/terraform-aws-virtual-service-module?ref=0.0.1"
+    source = "github.com/pbs/terraform-aws-virtual-service-module?ref=x.y.z"
 }
 ```
 
@@ -26,7 +26,7 @@ Integrate this module like so:
 
 ```hcl
 module "virtual-service" {
-  source = "github.com/pbs/terraform-aws-virtual-service-module?ref=0.0.1"
+  source = "github.com/pbs/terraform-aws-virtual-service-module?ref=x.y.z"
 
   mesh_name = module.mesh.id
 
@@ -46,7 +46,7 @@ module "virtual-service" {
 
 ```hcl
 module "virtual-service" {
-  source = "github.com/pbs/terraform-aws-virtual-service-module?ref=0.0.1"
+  source = "github.com/pbs/terraform-aws-virtual-service-module?ref=x.y.z"
 
   mesh_name = module.mesh.id
 
@@ -66,7 +66,7 @@ module "virtual-service" {
 
 If this repo is added as a subtree, then the version of the module should be close to the version shown here:
 
-`0.0.1`
+`x.y.z`
 
 Note, however that subtrees can be altered as desired within repositories.
 
@@ -100,7 +100,6 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_appmesh_virtual_service.virtual_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appmesh_virtual_service) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
 ## Inputs
 

--- a/data.tf
+++ b/data.tf
@@ -1,1 +1,0 @@
-data "aws_caller_identity" "current" {}

--- a/locals.tf
+++ b/locals.tf
@@ -13,7 +13,6 @@ locals {
       "${var.organization}:billing:product"     = var.product
       "${var.organization}:billing:environment" = var.environment
       creator                                   = local.creator
-      provisioner                               = data.aws_caller_identity.current.user_id
       repo                                      = var.repo
     }
   )


### PR DESCRIPTION
This tag doesn't help much, and causes issues with dependencies updating in weird orders.